### PR TITLE
Proposal: Make fights more fair

### DIFF
--- a/src/main/java/io/github/seggan/kingoftheziggurat/Ziggurat.java
+++ b/src/main/java/io/github/seggan/kingoftheziggurat/Ziggurat.java
@@ -1,6 +1,8 @@
 package io.github.seggan.kingoftheziggurat;
 
 import java.awt.*;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -61,10 +63,26 @@ public class Ziggurat {
             bot.strength++;
             bot.direction = MoveDirection.NONE;
         }
+        // group bots by position
+        HashMap<Point, ArrayList<Bot>> botsByPos = new HashMap<>();
         for (Bot bot : players.keySet()) {
-            for (Bot other : players.keySet()) {
-                if (bot != other && bot.getPosition().equals(other.getPosition())) {
-                    fightBots(bot, other);
+            botsByPos.computeIfAbsent(bot.getPosition(), pos -> new ArrayList<>()).add(bot);
+        }
+        // fight bots in the same squares
+        for (ArrayList<Bot> here : botsByPos.values()) {
+            Collections.shuffle(here, ThreadLocalRandom.current());
+            for (int i = 1; i < here.size(); i++) {
+                Bot aggressor = here.get(i);
+                for (int j = 0; j < i; j++) {
+                    Bot defender = here.get(j);
+                    // is the defender still here, or was it knocked down already?
+                    if (defender.getPosition().equals(aggressor.getPosition())) {
+                        fightBots(aggressor, defender);
+                        // was the aggressor knocked down now?
+                        if (aggressor.getPosition().equals(defender.getPosition())) {
+                            break;
+                        }
+                    }
                 }
             }
         }
@@ -74,34 +92,35 @@ public class Ziggurat {
     }
 
     private void fightBots(Bot bot, Bot other) {
+        // ask both bots simultaneously
         currentBot = bot;
-        if (bot.fight(other)) {
-            currentBot = other;
-            if (other.fight(bot)) {
-                int bot1;
-                int bot2;
-                int count = 0;
-                do {
-                    bot1 = nextInt(bot.strength / 2, bot.strength);
-                    bot2 = nextInt(other.strength / 2, other.strength);
-                    count++;
-                    if (count > 10) {
-                        return;
-                    }
-                } while (bot1 == bot2);
-                if (bot1 > bot2) {
-                    other.strength -= Math.ceil(other.strength * 0.2);
-                    bot.strength -= Math.ceil(bot.strength * 0.1);
-                    moveBotDown(other);
-                } else {
-                    bot.strength -= Math.ceil(bot.strength * 0.2);
-                    other.strength -= Math.ceil(other.strength * 0.1);
-                    moveBotDown(bot);
+        boolean botWants = bot.fight(other);
+        currentBot = other;
+        boolean otherWants = other.fight(bot);
+        if (botWants && otherWants) {
+            int bot1;
+            int bot2;
+            int count = 0;
+            do {
+                bot1 = nextInt(bot.strength / 2, bot.strength);
+                bot2 = nextInt(other.strength / 2, other.strength);
+                count++;
+                if (count > 10) {
+                    return;
                 }
-            } else {
+            } while (bot1 == bot2);
+            if (bot1 > bot2) {
+                other.strength -= Math.ceil(other.strength * 0.2);
+                bot.strength -= Math.ceil(bot.strength * 0.1);
                 moveBotDown(other);
+            } else {
+                bot.strength -= Math.ceil(bot.strength * 0.2);
+                other.strength -= Math.ceil(other.strength * 0.1);
+                moveBotDown(bot);
             }
-        } else {
+        } else if (botWants) {
+            moveBotDown(other);
+        } else if (otherWants) {
             moveBotDown(bot);
         }
     }

--- a/src/main/java/io/github/seggan/kingoftheziggurat/Ziggurat.java
+++ b/src/main/java/io/github/seggan/kingoftheziggurat/Ziggurat.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
@@ -64,12 +65,12 @@ public class Ziggurat {
             bot.direction = MoveDirection.NONE;
         }
         // group bots by position
-        HashMap<Point, ArrayList<Bot>> botsByPos = new HashMap<>();
+        Map<Point, List<Bot>> botsByPos = new HashMap<>();
         for (Bot bot : players.keySet()) {
             botsByPos.computeIfAbsent(bot.getPosition(), pos -> new ArrayList<>()).add(bot);
         }
         // fight bots in the same squares
-        for (ArrayList<Bot> here : botsByPos.values()) {
+        for (List<Bot> here : botsByPos.values()) {
             Collections.shuffle(here, ThreadLocalRandom.current());
             for (int i = 1; i < here.size(); i++) {
                 Bot aggressor = here.get(i);


### PR DESCRIPTION
Currently, there's a few potential issues in the fight code:

- Most importantly, there's currently no option for peace, unlike the challenge suggests (declining to fight is an instant step downwards)
- Multi-bot fighting order is `HashMap`-determined
- Bots may be forced to fight multiple times per tick if they fall down on top of other bots

This PR suggests a fix to the first issue and changes the fighting system to be consistently more fair (and random).

1. All bots that share squares are detected at first, so falling on another bot won't trigger a fight.
2. Each shared square's bots are randomly ordered ("arrival order").
3. For each square, each bot "arrives" in order and becomes the "aggressor" that has to fight every bot previously on that square (in arrival order).
4. Both bots in a fight are asked simultaneously if they want to fight, and if either wants to, the fight occurs.

This change can reduce follow-up fights and cause bots to group on the top square en masse (as they can now only fall one level per tick). It might make sense to re-run fights (without moving) until everyone is either at the bottom or on their own squares.